### PR TITLE
fix/soilprofile dtypes

### DIFF
--- a/src/owimetadatabase_preprocessor/soil/io.py
+++ b/src/owimetadatabase_preprocessor/soil/io.py
@@ -3,7 +3,7 @@ API client Module for the soil data in the OWIMetadatabase.
 """
 
 import warnings
-from typing import Callable, Dict, Union
+from typing import Callable, Dict, Union, Optional
 
 import numpy as np
 import pandas as pd
@@ -877,6 +877,8 @@ class SoilAPI(API):
         convert_to_profile: bool = True,
         profile_title: Union[str, None] = None,
         drop_info_cols: bool = True,
+        loading: Optional[str] = None,
+        formulation: Optional[str] = None,
         **kwargs,
     ) -> Dict[str, Union[pd.DataFrame, int, str, bool, requests.Response, None]]:
         """
@@ -888,8 +890,11 @@ class SoilAPI(API):
         :param soilprofile: Title of the soil profile (e.g. "Borehole log")
         :param convert_to_profile: Boolean determining whether the soil profile
             needs to be converted to a groundhog SoilProfile object
+        :param profile_title: Title for the soil profile
         :param drop_info_cols: Boolean determining whether or not to drop the
             columns with additional info (e.g. soil description, ...)
+        :param loading: Optional type of loading
+        :param formulation: Optional name of the formulation used to define the soil profile
         :return: Dictionary with the following keys:
             - 'id': id for the selected soil profile
             - 'soilprofilesummary': Metadata for the soil profile
@@ -919,7 +924,7 @@ class SoilAPI(API):
         }
         if convert_to_profile:
             dsp = SoilDataProcessor.convert_to_profile(
-                df_sum, df_detail, profile_title, drop_info_cols
+                df_sum, df_detail, profile_title, drop_info_cols, loading, formulation
             )
             dict_["soilprofile"] = dsp
             return dict_

--- a/src/owimetadatabase_preprocessor/soil/io.py
+++ b/src/owimetadatabase_preprocessor/soil/io.py
@@ -3,7 +3,7 @@ API client Module for the soil data in the OWIMetadatabase.
 """
 
 import warnings
-from typing import Callable, Dict, Union, Optional
+from typing import Callable, Dict, Optional, Union
 
 import numpy as np
 import pandas as pd

--- a/src/owimetadatabase_preprocessor/soil/processing/soil_pp.py
+++ b/src/owimetadatabase_preprocessor/soil/processing/soil_pp.py
@@ -6,12 +6,15 @@ and processed DataFrames, and extract/convert in-situ test detail data.
 
 import warnings
 import re
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 
 import pandas as pd
 from groundhog.general.soilprofile import profile_from_dataframe
 from groundhog.siteinvestigation.insitutests.pcpt_processing import PCPTProcessing
 from pyproj import Transformer
+
+if TYPE_CHECKING:
+    from groundhog.general.soilprofile import SoilProfile
 
 
 class SoilDataProcessor:
@@ -256,11 +259,15 @@ class SoilDataProcessor:
         :param formulation: Formulation used to define the soil profile.
         :return: Processed DataFrame with enforced dtypes.
         """
-        options = SoilprofileProcessor.get_available_options(loading=loading)
-        if formulation not in options:
+        if loading is None:
+            raise ValueError("Loading type must be specified to properly convert soil profile to groundhog object.")
+        if formulation is None:
+            raise ValueError("Formulation must be specified to properly convert soil profile to groundhog object.")
+        formulations = SoilprofileProcessor.get_available_options(loading=loading)
+        if formulation not in formulations:
             raise NotImplementedError(
                 f"Formulation '{formulation}' not yet supported for 'dtype' enforcement. "
-                f"Only '{options}' are available."
+                f"Only '{formulations}' are available."
             )
         if loading.lower() == "lateral":
             keys_mandatory = SoilprofileProcessor.LATERAL_SSI_KEYS[formulation]["mandatory"]
@@ -278,11 +285,11 @@ class SoilDataProcessor:
     def convert_to_profile(
         df_sum: pd.DataFrame,
         df_detail: pd.DataFrame,
-        profile_title: str,
+        profile_title: Optional[str],
         drop_info_cols: bool,
-        loading: str,
-        formulation: str
-    ) -> Union[groundhog.general.soilprofile.SoilProfile, None]:
+        loading: Optional[str],
+        formulation: Optional[str]
+    ) -> Optional["groundhog.general.soilprofile.SoilProfile"]:
         """Convert soil profile dataframe into a Groundhog soil profile representation.
 
         :param df_sum: Summary DataFrame containing general information about the soil profile.

--- a/src/owimetadatabase_preprocessor/soil/processing/soil_pp.py
+++ b/src/owimetadatabase_preprocessor/soil/processing/soil_pp.py
@@ -5,6 +5,7 @@ and processed DataFrames, and extract/convert in-situ test detail data.
 """
 
 import warnings
+import re
 from typing import Dict, List, Tuple, Union
 
 import pandas as pd
@@ -173,8 +174,124 @@ class SoilDataProcessor:
             return None
 
     @staticmethod
-    def convert_to_profile(df_sum, df_detail, profile_title, drop_info_cols):
-        # TODO: add docstring and type hints
+    def _coerce_columns_by_keys(
+        df: pd.DataFrame,
+        keys_mandatory: List[Union[str, Tuple[str, str]]],
+        keys_optional: List[Union[str, Tuple[str, str]]],
+    ) -> pd.DataFrame:
+        """Check names and enforce types for DataFrame columns based on a provided list of keys.
+
+        If the mandatory key is missing it will raise an error.
+        If the key ends with '[...]' (unit), then the matched column assumed numeric.
+        For tuple keys: ALL tuple elements must be present in at least one column name; treated as numeric always.
+        Extra DataFrame columns not matching any key are left unchanged.
+
+        :param df: DataFrame to process.
+        :param keys_mandatory: List of mandatory keys to match against DataFrame columns.
+        :param keys_optional: List of optional keys to match against DataFrame columns.
+        :return: DataFrame with coerced column types.
+        """
+        df_processed = df.copy()
+
+        def normalize(s: str) -> str:
+            return " ".join(s.split()).strip().lower()
+
+        def has_trailing_unit(s: str) -> bool:
+            return re.search(r"\[[^]]+\]\s*$", s) is not None
+
+        def process_keys(keys: List[Union[str, Tuple[str, str]]]) -> Tuple[List[str], List[Tuple[str, str]]]:
+            string_keys = [normalize(k) for k in keys if isinstance(k, str)]
+            tuple_keys = []
+            for k in keys:
+                if isinstance(k, tuple):
+                    tuple_keys.append(tuple(normalize(elem) for elem in k))
+            return string_keys, tuple_keys
+        
+        string_keys_mandatory, tuple_keys_mandatory = process_keys(keys_mandatory)
+        string_keys_optional, tuple_keys_optional = process_keys(keys_optional)
+
+        cols_norm = {col: normalize(col) for col in df_processed.columns}
+
+        def match_string_key(string_key: str) -> List[str]:
+            return [col for col in df_processed.columns if string_key in cols_norm[col]]
+
+        def match_tuple_key(tuple_key: Tuple[str, ...]) -> List[str]:
+            return [
+                col for col in df_processed.columns
+                if all(elem in cols_norm[col] for elem in tuple_key)
+            ]
+
+        for string_key in string_keys_mandatory:
+            matches = match_string_key(string_key)
+            if not matches:
+                raise KeyError(f"Mandatory key '{string_key}' not found in DataFrame columns.")
+            if has_trailing_unit(string_key):
+                for col in matches:
+                    df_processed[col] = pd.to_numeric(df_processed[col], errors="coerce")
+
+        for tuple_key in tuple_keys_mandatory:
+            matches = match_tuple_key(tuple_key)
+            if not matches:
+                raise KeyError(f"Mandatory key '{tuple_key}' not found in DataFrame columns.")
+            for col in matches:
+                df_processed[col] = pd.to_numeric(df_processed[col], errors="coerce")
+
+        for string_key in string_keys_optional:
+            if has_trailing_unit(string_key):
+                for col in match_string_key(string_key):
+                    df_processed[col] = pd.to_numeric(df_processed[col], errors="coerce")
+
+        for tuple_key in tuple_keys_optional:
+            for col in match_tuple_key(tuple_key):
+                df_processed[col] = pd.to_numeric(df_processed[col], errors="coerce")
+
+        return df_processed
+
+    @staticmethod
+    def _process_soilprofile_cols(df: pd.DataFrame, loading: str, formulation: str) -> pd.DataFrame:
+        """Process soil profile DataFrame columns based on the specified loading type and option.
+
+        :param df: DataFrame to process.
+        :param loading: Loading type (e.g., "lateral" or "axial").
+        :param formulation: Formulation used to define the soil profile.
+        :return: Processed DataFrame with enforced dtypes.
+        """
+        options = SoilprofileProcessor.get_available_options(loading=loading)
+        if formulation not in options:
+            raise NotImplementedError(
+                f"Formulation '{formulation}' not yet supported for 'dtype' enforcement. "
+                f"Only '{options}' are available."
+            )
+        if loading.lower() == "lateral":
+            keys_mandatory = SoilprofileProcessor.LATERAL_SSI_KEYS[formulation]["mandatory"]
+            keys_optional = SoilprofileProcessor.LATERAL_SSI_KEYS[formulation]["optional"]
+        elif loading.lower() == "axial":
+            keys_mandatory = SoilprofileProcessor.AXIAL_SSI_KEYS[formulation]["mandatory"]
+            keys_optional = SoilprofileProcessor.AXIAL_SSI_KEYS[formulation]["optional"]
+        else:
+            raise NotImplementedError(
+                f"Loading type '{loading}' not yet supported for 'dtype' enforcement."
+            )
+        return SoilDataProcessor._coerce_columns_by_keys(df, keys_mandatory, keys_optional)
+
+    @staticmethod
+    def convert_to_profile(
+        df_sum: pd.DataFrame,
+        df_detail: pd.DataFrame,
+        profile_title: str,
+        drop_info_cols: bool,
+        loading: str,
+        formulation: str
+    ) -> Union[groundhog.general.soilprofile.SoilProfile, None]:
+        """Convert soil profile dataframe into a Groundhog soil profile representation.
+
+        :param df_sum: Summary DataFrame containing general information about the soil profile.
+        :param df_detail: Detail DataFrame containing specific information about soil layers.
+        :param profile_title: Title for the soil profile.
+        :param drop_info_cols: Boolean indicating whether to drop informational columns.
+        :param loading: Optional type of loading.
+        :param formulation: Optional name of the formulation used to define the soil profile.
+        """
         try:
             soilprofile_df = (
                 pd.DataFrame(df_detail["soillayer_set"].iloc[0])
@@ -196,24 +313,7 @@ class SoilDataProcessor:
                         soilprofile_df.loc[i, key] = value
                 except Exception:
                     pass
-            for col in soilprofile_df.columns:
-                is_numeric_col = True
-                for value in soilprofile_df[col]:
-                    if value is None or pd.isna(value) or value == "" or value == "None" or value == "null":
-                        continue
-                    if not isinstance(value, (int, float)):
-                        try:
-                            float(value)
-                        except (ValueError, TypeError):
-                            is_numeric_col = False
-                            break
-                if is_numeric_col:
-                    try:
-                        soilprofile_df[col] = pd.to_numeric(soilprofile_df[col])
-                    except Exception as err:
-                        warnings.warn(
-                            f"Error converting column '{col}' to numeric: {err}"
-                        )
+            soilprofile_df = SoilDataProcessor._process_soilprofile_cols(soilprofile_df, loading, formulation)
             if profile_title is None:
                 profile_title = (
                     f"{df_sum['location_name'].iloc[0]} - {df_sum['title'].iloc[0]}"

--- a/tests/soil/processing/data/convert_input_pisa.json
+++ b/tests/soil/processing/data/convert_input_pisa.json
@@ -1,0 +1,93 @@
+[
+    {
+        "id": 1111,
+        "location_name": "TEST_LOC",
+        "title": "TEST_SP",
+        "soillayer_set": [
+            {
+                "id": 101,
+                "soilunit_name": "Generic SAND",
+                "soiltype_name": "SAND",
+                "soilprofile_name": "TEST_SP",
+                "start_depth": 0.0,
+                "end_depth": 15.0,
+                "description": "",
+                "totalunitweight": 20.0,
+                "soilparameters": {
+                    "Dr to [-]": 1.0,
+                    "Soil type": "SAND",
+                    "Dr from [-]": 1.0,
+                    "Su to [kPa]": null,
+                    "Gmax to [kPa]": 190000.05,
+                    "Su from [kPa]": null,
+                    "Gmax from [kPa]": 0.0
+                },
+                "profile": 1111,
+                "soilunit": 239
+            }, 
+            {
+                "id": 102,
+                "soilunit_name": "Generic SAND",
+                "soiltype_name": "SAND",
+                "soilprofile_name": "TEST_SP",
+                "start_depth": 15.0,
+                "end_depth": 17.5,
+                "description": "",
+                "totalunitweight": 20.0,
+                "soilparameters": {
+                    "Dr to [-]": 1.0,
+                    "Soil type": "SAND",
+                    "Dr from [-]": 1.0,
+                    "Su to [kPa]": null,
+                    "Gmax to [kPa]": 205000.9,
+                    "Su from [kPa]": null,
+                    "Gmax from [kPa]": 195000.1
+                },
+                "profile": 1111,
+                "soilunit": 239
+            }, 
+            {
+                "id": 103,
+                "soilunit_name": "Generic SAND",
+                "soiltype_name": "SAND",
+                "soilprofile_name": "TEST_SP",
+                "start_depth": 17.5,
+                "end_depth": 20.0,
+                "description": "",
+                "totalunitweight": 20.0,
+                "soilparameters": {
+                    "Dr to [-]": 0.9111,
+                    "Soil type": "SAND",
+                    "Dr from [-]": 0.7777,
+                    "Su to [kPa]": null,
+                    "Gmax to [kPa]": 225000.005,
+                    "Su from [kPa]": null,
+                    "Gmax from [kPa]": 175000.81
+                },
+                "profile": 1111,
+                "soilunit": 239
+            }, 
+            {
+                "id": 104,
+                "soilunit_name": "Generic CLAY",
+                "soiltype_name": "CLAY",
+                "soilprofile_name": "TEST_SP",
+                "start_depth": 20.0,
+                "end_depth": 30.0,
+                "description": "",
+                "totalunitweight": 20.0,
+                "soilparameters": {
+                    "Dr to [-]": null,
+                    "Soil type": "CLAY",
+                    "Dr from [-]": null,
+                    "Su to [kPa]": 125.666,
+                    "Gmax to [kPa]": 197500.11,
+                    "Su from [kPa]": 100.35,
+                    "Gmax from [kPa]": 115000.25
+                },
+                "profile": 1111,
+                "soilunit": 239
+            }
+        ]
+    }
+]

--- a/tests/soil/processing/data/convert_output_pisa.json
+++ b/tests/soil/processing/data/convert_output_pisa.json
@@ -1,0 +1,50 @@
+[
+    {
+        "Depth from [m]": 0,
+        "Depth to [m]": 15.0,
+        "Soil type": "SAND",
+        "Gmax from [kPa]": 0.0,
+        "Gmax to [kPa]": 190000.05,
+        "Su from [kPa]": null,
+        "Su to [kPa]": null,
+        "Dr from [-]": 1.0,
+        "Dr to [-]": 1.0,
+        "Total unit weight [kN/m3]": 20.0
+    },
+    {
+        "Depth from [m]": 15.0,
+        "Depth to [m]": 17.5,
+        "Soil type": "SAND",
+        "Gmax from [kPa]": 195000.1,
+        "Gmax to [kPa]": 205000.9,
+        "Su from [kPa]": null,
+        "Su to [kPa]": null,
+        "Dr from [-]": 1.0,
+        "Dr to [-]": 1.0,
+        "Total unit weight [kN/m3]": 20.0
+    },
+    {
+        "Depth from [m]": 17.5,
+        "Depth to [m]": 20.0,
+        "Soil type": "SAND",
+        "Gmax from [kPa]": 175000.81,
+        "Gmax to [kPa]": 225000.005,
+        "Su from [kPa]": null,
+        "Su to [kPa]": null,
+        "Dr from [-]": 0.7777,
+        "Dr to [-]": 0.9111,
+        "Total unit weight [kN/m3]": 20.0
+    },
+    {
+        "Depth from [m]": 20.0,
+        "Depth to [m]": 30.0,
+        "Soil type": "CLAY",
+        "Gmax from [kPa]": 115000.25,
+        "Gmax to [kPa]": 197500.11,
+        "Su from [kPa]": 100.35,
+        "Su to [kPa]": 125.666,
+        "Dr from [-]": null,
+        "Dr to [-]": null,
+        "Total unit weight [kN/m3]": 20.0
+    }
+]

--- a/tests/soil/processing/test_soil_pp.py
+++ b/tests/soil/processing/test_soil_pp.py
@@ -3,9 +3,9 @@ import os
 
 import pandas as pd
 import pytest
+from groundhog.general.soilprofile import profile_from_dataframe
 
 from owimetadatabase_preprocessor.soil import SoilDataProcessor, SoilprofileProcessor
-from groundhog.general.soilprofile import profile_from_dataframe
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 
@@ -173,25 +173,29 @@ def test_convert_to_profile(filename_input: str, filename_output: str) -> None:
         data_input = json.load(f)
     with open(filepath_output, "r") as f:
         data_output = json.load(f)
-    
+
     df_input = pd.DataFrame(data_input)
     df_output = pd.DataFrame(data_output)
 
-    cols_not_numeric = {"Soil type",}
+    cols_not_numeric = {
+        "Soil type",
+    }
     cols_numeric = df_output.columns.difference(cols_not_numeric)
-    df_output[cols_numeric] = df_output[cols_numeric].apply(pd.to_numeric, errors="coerce")
+    df_output[cols_numeric] = df_output[cols_numeric].apply(
+        pd.to_numeric, errors="coerce"
+    )
 
     groundhog_profile = profile_from_dataframe(df_output)
-    
+
     df_temp = pd.DataFrame(
         {
-            "location_name": [df_input['location_name'].iloc[0]],
-            "title": [df_input['title'].iloc[0]],
+            "location_name": [df_input["location_name"].iloc[0]],
+            "title": [df_input["title"].iloc[0]],
         }
     )
-    
+
     result = SoilDataProcessor.convert_to_profile(
-        df_temp, df_input, None, True, loading='lateral', formulation='pisa'
+        df_temp, df_input, None, True, loading="lateral", formulation="pisa"
     )
-    
+
     pd.testing.assert_frame_equal(result, groundhog_profile, check_like=True)

--- a/tests/soil/processing/test_soil_pp.py
+++ b/tests/soil/processing/test_soil_pp.py
@@ -4,7 +4,8 @@ import os
 import pandas as pd
 import pytest
 
-from owimetadatabase_preprocessor.soil import SoilprofileProcessor
+from owimetadatabase_preprocessor.soil import SoilDataProcessor, SoilprofileProcessor
+from groundhog.general.soilprofile import profile_from_dataframe
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 
@@ -153,3 +154,44 @@ def test_lateral_pisa(filename: str, mudline: float) -> None:
     assert not any(
         "epsilon50" in col for col in result.columns
     ), "Columns from apirp2geo method are present."
+
+
+@pytest.mark.parametrize(
+    "filename_input, filename_output",
+    [
+        ("convert_input_pisa.json", "convert_output_pisa.json"),
+    ],
+)
+def test_convert_to_profile(filename_input: str, filename_output: str) -> None:
+    """Test convert profile lateral method with option 'pisa'.
+
+    The purpose mostly just to ensure dtype consistency.
+    """
+    filepath_input = os.path.join(DATA_DIR, filename_input)
+    filepath_output = os.path.join(DATA_DIR, filename_output)
+    with open(filepath_input, "r") as f:
+        data_input = json.load(f)
+    with open(filepath_output, "r") as f:
+        data_output = json.load(f)
+    
+    df_input = pd.DataFrame(data_input)
+    df_output = pd.DataFrame(data_output)
+
+    cols_not_numeric = {"Soil type",}
+    cols_numeric = df_output.columns.difference(cols_not_numeric)
+    df_output[cols_numeric] = df_output[cols_numeric].apply(pd.to_numeric, errors="coerce")
+
+    groundhog_profile = profile_from_dataframe(df_output)
+    
+    df_temp = pd.DataFrame(
+        {
+            "location_name": [df_input['location_name'].iloc[0]],
+            "title": [df_input['title'].iloc[0]],
+        }
+    )
+    
+    result = SoilDataProcessor.convert_to_profile(
+        df_temp, df_input, None, True, loading='lateral', formulation='pisa'
+    )
+    
+    pd.testing.assert_frame_equal(result, groundhog_profile, check_like=True)


### PR DESCRIPTION
Attemp to more robust "convert to Groundhog SoilProfile object" given the enforcement of columns per loading/formulation and recent bug fix.

Suggestions to extend or simplify etc. are welcome. Some things might be redundant (double checking the same thing) depending on the workflow but I am not knowledgeable enough about various workflows with Soil module to judge.

- Enforces a user to define `loading` and `formulation` type if want to convert profile
- Validation of correct input columns (as pre-defined by devs) and type conversion
- Added a test with fake data to check correct `dtypes`